### PR TITLE
スタートアップにショートカットが登録されていない場合に登録するフローを追加

### DIFF
--- a/SyuKKINNNOSUKE/Program.cs
+++ b/SyuKKINNNOSUKE/Program.cs
@@ -199,21 +199,26 @@ namespace SyuKKINNNOSUKE
             var applicationName = ApplicationName();
             var exePath = $@"{Directory.GetCurrentDirectory()}\{applicationName}.exe";
 
+            // 72C24DD5-D70A-438B-8A42-98424B88AFB8(Windwos Script Hostを使用するオブジェクトの生成)
             Type t = Type.GetTypeFromCLSID(new Guid("72C24DD5-D70A-438B-8A42-98424B88AFB8"));
             object shell = Activator.CreateInstance(t);
 
+            // ショートカットの作成
             object shortcut = t.InvokeMember("CreateShortcut",
                 BindingFlags.InvokeMethod, null, shell,
                 new object[] { startUpFilePath });
 
+            // ショートカットの実行パス設定
             t.InvokeMember("TargetPath",
                 BindingFlags.SetProperty, null, shortcut,
                 new object[] { exePath });
 
+            // ショートカットファイルのアイコン設定
             t.InvokeMember("IconLocation",
                 BindingFlags.SetProperty, null, shortcut,
                 new object[] { exePath + ",0" });
 
+            // 保存
             t.InvokeMember("Save",
                 BindingFlags.InvokeMethod,
                 null, shortcut, null);

--- a/SyuKKINNNOSUKE/Program.cs
+++ b/SyuKKINNNOSUKE/Program.cs
@@ -199,32 +199,52 @@ namespace SyuKKINNNOSUKE
             var applicationName = ApplicationName();
             var exePath = $@"{Directory.GetCurrentDirectory()}\{applicationName}.exe";
 
-            // 72C24DD5-D70A-438B-8A42-98424B88AFB8(Windwos Script Hostを使用するオブジェクトの生成)
-            Type t = Type.GetTypeFromCLSID(new Guid("72C24DD5-D70A-438B-8A42-98424B88AFB8"));
-            object shell = Activator.CreateInstance(t);
+            object shell = null;
+            object shortcut = null;
+            try
+            {
+                // 72C24DD5-D70A-438B-8A42-98424B88AFB8(Windwos Script Hostを使用するオブジェクトの生成)
+                Type t = Type.GetTypeFromCLSID(new Guid("72C24DD5-D70A-438B-8A42-98424B88AFB8"));
+                shell = Activator.CreateInstance(t);
 
-            // ショートカットの作成
-            object shortcut = t.InvokeMember("CreateShortcut",
-                BindingFlags.InvokeMethod, null, shell,
-                new object[] { startUpFilePath });
+                // ショートカットの作成
+                shortcut = t.InvokeMember("CreateShortcut",
+                    BindingFlags.InvokeMethod, null, shell,
+                    new object[] { startUpFilePath });
 
-            // ショートカットの実行パス設定
-            t.InvokeMember("TargetPath",
-                BindingFlags.SetProperty, null, shortcut,
-                new object[] { exePath });
+                // ショートカットの実行パス設定
+                t.InvokeMember("TargetPath",
+                    BindingFlags.SetProperty, null, shortcut,
+                    new object[] { exePath });
 
-            // ショートカットファイルのアイコン設定
-            t.InvokeMember("IconLocation",
-                BindingFlags.SetProperty, null, shortcut,
-                new object[] { exePath + ",0" });
+                // ショートカットファイルのアイコン設定
+                t.InvokeMember("IconLocation",
+                    BindingFlags.SetProperty, null, shortcut,
+                    new object[] { exePath + ",0" });
 
-            // 保存
-            t.InvokeMember("Save",
-                BindingFlags.InvokeMethod,
-                null, shortcut, null);
+                // 保存
+                t.InvokeMember("Save",
+                    BindingFlags.InvokeMethod,
+                    null, shortcut, null);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            finally
+            {
+                if (shortcut != null)
+                {
+                    Marshal.FinalReleaseComObject(shortcut);
+                    shortcut = null;
+                }
 
-            Marshal.FinalReleaseComObject(shortcut);
-            Marshal.FinalReleaseComObject(shell);
+                if (shell != null)
+                {
+                    Marshal.FinalReleaseComObject(shell);
+                    shell = null;
+                }
+            }
         }
 
         private static bool NotExistsStartupFile()

--- a/SyuKKINNNOSUKE/Program.cs
+++ b/SyuKKINNNOSUKE/Program.cs
@@ -59,7 +59,7 @@ namespace SyuKKINNNOSUKE
                 Environment.SetEnvironmentVariable(EnvironmentVarPassword, ToUnreadable(password, key), EnvironmentVariableTarget.User);
                 Environment.SetEnvironmentVariable(EnvironmentVarKey, key, EnvironmentVariableTarget.User);
 
-                if (!ExistsStartupFile())
+                if (NotExistsStartupFile())
                 {
                     Console.WriteLine("スタートアップに登録しますか？(y/(any))");
                     var res = Console.ReadLine();
@@ -222,9 +222,9 @@ namespace SyuKKINNNOSUKE
             Marshal.FinalReleaseComObject(shell);
         }
 
-        private static bool ExistsStartupFile()
+        private static bool NotExistsStartupFile()
         {
-            return File.Exists(StartupFilePath());
+            return !File.Exists(StartupFilePath());
         }
 
         private static string StartupFilePath()


### PR DESCRIPTION
# 追加する機能について
- スタートアップにショートカットが登録されていない場合に登録するフローを追加
  - 初期設定時のフローの認識なので、ユーザー情報設定のフローに組み込んでいます。
  - `clear` オプションで設定情報がClearされることもあるかと思うので、ショートカットの存在チェックの後、存在しなければショートカットを作成する処理を実行しています。

